### PR TITLE
Logic to handle candidates with zero votes in Section 273(18)

### DIFF
--- a/dividebatur/counter.py
+++ b/dividebatur/counter.py
@@ -393,9 +393,11 @@ class SenateCounter:
         }
         transfer = None
         if len(self.candidates_elected) != self.vacancies:
-            excess_votes = candidate_aggregates.get_vote_count(candidate_id) - self.quota
+            excess_votes = max(candidate_aggregates.get_vote_count(candidate_id) - self.quota, 0)
             assert(excess_votes >= 0)
-            transfer_value = fractions.Fraction(excess_votes, self.candidate_bundle_transactions.paper_count(candidate_id))
+            transfer_value = 0
+            if self.candidate_bundle_transactions.paper_count(candidate_id):
+                transfer_value = fractions.Fraction(excess_votes, self.candidate_bundle_transactions.paper_count(candidate_id))
             assert(transfer_value >= 0)
             self.election_distributions_pending.append((candidate_id, transfer_value, excess_votes))
             transfer = excess_votes, float(transfer_value)


### PR DESCRIPTION
Section 273(18) states that if we are down to N vacancies in the contest and there are N candidates remaining, those candidates assume the N vacancies. When computing the outcome on a subset of tickets in the contest, I found that the assertion in ``counter.elect`` was failing. Upon further investigation, I discovered that this code was being hit with some of the N candidates remaining having zero (or less than quota) votes. Then the difference between their votes and the quote was negative. In addition, ``fractions.Fraction`` expects the denominator to be non-zero and when the candidate's votes are zero, this raises an Exception. Thus, I added the proper logic to handle these cases.