### PR TITLE
Refactor candidate list classes

### DIFF
--- a/dividebatur/aecdata/__init__.py
+++ b/dividebatur/aecdata/__init__.py
@@ -2,7 +2,7 @@ import itertools
 import csv
 import re
 from collections import namedtuple, defaultdict
-from . counter import Ticket
+from ..counter import Ticket
 
 
 def int_or_none(s):

--- a/dividebatur/aecdata/__init__.py
+++ b/dividebatur/aecdata/__init__.py
@@ -17,61 +17,6 @@ def int_or_none(s):
         return None
 
 
-class AllCandidates:
-    "parse AEC 'all candidates' CSV file"
-
-    def __init__(self, csv_file, state):
-        self.state = state
-        self.load(csv_file)
-
-    def load(self, csv_file):
-        self.groups = defaultdict(list)
-        with open(csv_file, 'rt') as fd:
-            reader = csv.reader(fd)
-            header = next(reader)
-            for candidate in sorted(named_tuple_iter('AllCandidate', reader, header, ballot_position=int), key=lambda row: (ticket_sort_key(row.ticket), row.ballot_position)):
-                if candidate.state_ab != self.state:
-                    continue
-                if candidate.nom_ty != 'S':
-                    continue
-                self.groups[candidate.ticket].append(candidate)
-
-
-class SenateFlows:
-    "work out the flow per group above the line (post 2015)"
-
-    def __init__(self, candidates, all_candidates):
-        self.groups = []
-        self.flows = defaultdict(list)
-        self.btl = []
-        self.candidate_title = {}
-        self.match(candidates, all_candidates)
-
-    def get_candidate_ids(self):
-        return list(self.btl)
-
-    def get_candidate_title(self, candidate_id):
-        return self.candidate_title[candidate_id]
-
-    def get_candidate_order(self, candidate_id):
-        return self.btl.index(candidate_id)
-
-    def match(self, candidates, all_candidates):
-        # UG: ungrouped (not a real group, placing a '1' in this ATL is a trap). doesn't
-        # count for ATL flows, but does count for BTL ordering
-        all_groups = [t for t in sorted(all_candidates.groups.keys(), key=ticket_sort_key)]
-        for group in all_groups:
-            ac = all_candidates.groups[group]
-            for all_candidate in ac:
-                k = (all_candidate.surname, all_candidate.ballot_given_nm, all_candidate.party_ballot_nm)
-                matched = candidates.by_name_party[k]
-                if group != 'UG':
-                    self.flows[group].append(matched.CandidateID)
-                self.btl.append(matched.CandidateID)
-                self.candidate_title[matched.CandidateID] = matched.Surname + ', ' + matched.GivenNm
-        self.groups = [t for t in all_groups if t != 'UG']
-
-
 class FormalPreferences:
     "parse AEC 'formal preferences' CSV file"
 

--- a/dividebatur/aecdata/__init__.py
+++ b/dividebatur/aecdata/__init__.py
@@ -1,7 +1,10 @@
 import itertools
 import csv
 import re
-from collections import namedtuple, defaultdict
+from collections import defaultdict
+
+from .candidatelist import CandidateList
+from .utils import named_tuple_iter, ticket_sort_key
 from ..counter import Ticket
 
 
@@ -12,25 +15,6 @@ def int_or_none(s):
         return int(s)
     except ValueError:
         return None
-
-
-def ticket_sort_key(ticket):
-    "sort key for an ATL ticket, eg. A..Z, AA..ZZ"
-    return (len(ticket), ticket)
-
-
-def named_tuple_iter(name, reader, header, **kwargs):
-    field_names = [t for t in [t.strip().replace('-', '_')
-                               for t in header] if t]
-    typ = namedtuple(name, field_names)
-    mappings = []
-    for field_name in kwargs:
-        idx = field_names.index(field_name)
-        mappings.append((idx, kwargs[field_name]))
-    for row in reader:
-        for idx, map_fn in mappings:
-            row[idx] = map_fn(row[idx])
-        yield typ(*row)
 
 
 class AllCandidates:

--- a/dividebatur/aecdata/candidatelist.py
+++ b/dividebatur/aecdata/candidatelist.py
@@ -48,7 +48,7 @@ class CandidateList:
         self.groups = []
         self.group_by_id = {}
 
-        candidate_by_name_party, party_ab = self._load_senate_candidate(
+        candidate_by_name_party, party_ab = self._load_senate_candidates(
             senate_candidates_csv)
         current_group = None
         current_party = None
@@ -102,7 +102,7 @@ class CandidateList:
                 candidates.append(candidate)
         return candidates
 
-    def _load_senate_candidate(self, senate_candidates_csv):
+    def _load_senate_candidates(self, senate_candidates_csv):
         by_name_party = {}
         party_ab = {}
         seen_ids = set()

--- a/dividebatur/aecdata/candidatelist.py
+++ b/dividebatur/aecdata/candidatelist.py
@@ -1,8 +1,7 @@
 import csv
 import collections
 
-from . import (
-    ticket_sort_key, named_tuple_iter)
+from .utils import ticket_sort_key, named_tuple_iter
 
 
 Candidate = collections.namedtuple('Candidate', [
@@ -15,13 +14,27 @@ Candidate = collections.namedtuple('Candidate', [
     'party_name',
 ])
 
+
 Group = collections.namedtuple('Group', [
     'group_id',
     'party_name',
     'candidates', # Ordered list of candidates in group
 ])
 
+
 class CandidateList:
+    """CandidateList provides a list of senate candidates and groups.
+
+    The following members are publicly accessible:
+
+      - candidates: a list of all candidates, in the order they appear
+        on the ballot.
+      - candidate_by_id: a dictionary mapping candidate IDs to the candidate.
+      - groups: a list of groups, in the order they appear on the
+        ballot.  Does not include the ungrouped candidates.
+      - group_by_id: a dictionary mapping group IDs (e.g. A, B, ...)
+        to the group.
+    """
 
     def __init__(self, state, all_candidates_csv, senate_candidates_csv):
         self.state = state

--- a/dividebatur/aecdata/utils.py
+++ b/dividebatur/aecdata/utils.py
@@ -1,0 +1,20 @@
+from collections import namedtuple
+
+
+def named_tuple_iter(name, reader, header, **kwargs):
+    field_names = [t for t in [t.strip().replace('-', '_')
+                               for t in header] if t]
+    typ = namedtuple(name, field_names)
+    mappings = []
+    for field_name in kwargs:
+        idx = field_names.index(field_name)
+        mappings.append((idx, kwargs[field_name]))
+    for row in reader:
+        for idx, map_fn in mappings:
+            row[idx] = map_fn(row[idx])
+        yield typ(*row)
+
+
+def ticket_sort_key(ticket):
+    "sort key for an ATL ticket, eg. A..Z, AA..ZZ"
+    return (len(ticket), ticket)

--- a/dividebatur/senatecount.py
+++ b/dividebatur/senatecount.py
@@ -9,21 +9,21 @@ import re
 import glob
 from pprint import pprint, pformat
 from .counter import PapersForCount, SenateCounter, Ticket
-from .aecdata import Candidates, SenateATL, SenateBTL, AllCandidates, SenateFlows, FormalPreferences
+from .aecdata import Candidates, CandidateList, SenateATL, SenateBTL, FormalPreferences
 
 
 class SenateCountPost2015:
     def __init__(self, state_name, get_input_file, **kwargs):
-        self.candidates = Candidates(get_input_file('senate-candidates'))
-        self.all_candidates = AllCandidates(get_input_file('all-candidates'), state_name)
-        self.flows = SenateFlows(self.candidates, self.all_candidates)
+        self.candidates = CandidateList(state_name,
+                                        get_input_file('all-candidates'),
+                                        get_input_file('senate-candidates'))
         self.tickets_for_count = PapersForCount()
 
         self.s282_candidates = kwargs.get('s282_candidates')
 
         def atl_flow(form):
             by_pref = {}
-            for pref, group in zip(form, self.flows.groups):
+            for pref, group in zip(form, self.candidates.groups):
                 if pref is None:
                     continue
                 if pref not in by_pref:
@@ -35,7 +35,8 @@ class SenateCountPost2015:
                 if not at_pref or len(at_pref) != 1:
                     break
                 the_pref = at_pref[0]
-                for candidate_id in self.flows.flows[the_pref]:
+                for candidate in the_pref.candidates:
+                    candidate_id = candidate.candidate_id
                     # s282: exclude candidates not elected in first (full senate) count
                     if self.s282_candidates and candidate_id not in self.s282_candidates:
                         continue
@@ -51,12 +52,12 @@ class SenateCountPost2015:
             else:
                 min_prefs = 6
             by_pref = {}
-            for pref, candidate_id in zip(form, self.flows.btl):
+            for pref, candidate in zip(form, self.candidates.candidates):
                 if pref is None:
                     continue
                 if pref not in by_pref:
                     by_pref[pref] = []
-                by_pref[pref].append(candidate_id)
+                by_pref[pref].append(candidate.candidate_id)
             prefs = []
             for i in range(1, len(form) + 1):
                 at_pref = by_pref.get(i)
@@ -72,8 +73,8 @@ class SenateCountPost2015:
                 return None
             return Ticket(tuple(prefs))
 
-        atl_n = len(self.flows.groups)
-        btl_n = len(self.flows.btl)
+        atl_n = len(self.candidates.groups)
+        btl_n = len(self.candidates.candidates)
         informal_n = 0
         for raw_form, count in FormalPreferences(get_input_file('formal-preferences')):
             assert(len(raw_form) == atl_n + btl_n)
@@ -91,21 +92,24 @@ class SenateCountPost2015:
         return self.tickets_for_count
 
     def get_candidate_ids(self):
-        if not self.s282_candidates:
-            return self.flows.get_candidate_ids()
-        return [t for t in self.flows.get_candidate_ids() if t in self.s282_candidates]
+        candidate_ids = [c.candidate_id for c in self.candidates.candidates]
+        if self.s282_candidates:
+            candidate_ids = [t for t in candidate_ids if t in self.s282_candidates]
+        return candidate_ids
 
     def get_parties(self):
-        return self.candidates.get_parties()
+        return dict((c.party_abbreviation, c.party_name)
+                    for c in self.candidates.candidates)
 
     def get_candidate_title(self, candidate_id):
-        return self.flows.get_candidate_title(candidate_id)
+        c = self.candidates.candidate_by_id[candidate_id]
+        return "{}, {}".format(c.surname, c.given_name)
 
     def get_candidate_order(self, candidate_id):
-        return self.flows.get_candidate_order(candidate_id)
+        return self.candidates.candidate_by_id[candidate_id].candidate_order
 
     def get_candidate_party(self, candidate_id):
-        return self.candidates.lookup_id(candidate_id).PartyAb
+        return self.candidates.candidate_by_id[candidate_id].party_abbreviation
 
 
 class SenateCountPre2015:

--- a/dividebatur/tests/test_candidatelist.py
+++ b/dividebatur/tests/test_candidatelist.py
@@ -2,7 +2,7 @@ import os
 import unittest
 
 import dividebatur
-from dividebatur.aecdata.candidatelist import CandidateList
+from dividebatur.aecdata import CandidateList
 
 datadir = os.path.join(os.path.dirname(dividebatur.__file__),
                        os.pardir, "aec_data")

--- a/dividebatur/tests/test_candidatelist.py
+++ b/dividebatur/tests/test_candidatelist.py
@@ -1,0 +1,106 @@
+import os
+import unittest
+
+import dividebatur
+from dividebatur.aecdata.candidatelist import CandidateList
+
+datadir = os.path.join(os.path.dirname(dividebatur.__file__),
+                       os.pardir, "aec_data")
+
+class CandidateListTests(unittest.TestCase):
+
+    def test_fed2013(self):
+        all_candidates_csv = os.path.join(
+            datadir, "fed2013", "common",
+            "2013federalelection-all-candidates-nat-22-08.csv")
+        senate_candidates_csv = os.path.join(
+            datadir, "fed2013", "common",
+            "SenateCandidatesDownload-17496.csv")
+
+        cl = CandidateList("NSW", all_candidates_csv, senate_candidates_csv)
+
+        self.assertEqual(110, len(cl.candidates))
+        self.assertEqual(44, len(cl.groups))
+
+        first_candidate = cl.candidates[0]
+        self.assertEqual(24801, first_candidate.candidate_id)
+        self.assertEqual("LEYONHJELM", first_candidate.surname)
+        self.assertEqual("David", first_candidate.given_name)
+        self.assertEqual(0, first_candidate.candidate_pos)
+        self.assertEqual("A", first_candidate.group_id)
+        self.assertEqual(1, first_candidate.ballot_position)
+        self.assertEqual("Liberal Democrats", first_candidate.party_name)
+
+        last_candidate = cl.candidates[-1]
+        self.assertEqual(24866, last_candidate.candidate_id)
+        self.assertEqual("La MELA", last_candidate.surname)
+        self.assertEqual("John", last_candidate.given_name)
+        self.assertEqual(109, last_candidate.candidate_pos)
+        self.assertEqual("UG", last_candidate.group_id)
+        self.assertEqual(4, last_candidate.ballot_position)
+        self.assertEqual("Independent", last_candidate.party_name)
+
+        first_group = cl.groups[0]
+        self.assertEqual("A", first_group.group_id)
+        self.assertEqual("Liberal Democrats", first_group.party_name)
+        self.assertEqual(2, len(first_group.candidates))
+        self.assertIs(first_candidate, first_group.candidates[0])
+
+        # Even though the "UG" candidates appear last on the ballot,
+        # they do not count as a group.
+        last_group = cl.groups[-1]
+        self.assertEqual("AR", last_group.group_id)
+        self.assertEqual("One Nation", last_group.party_name)
+
+        # Lookup by ID
+        self.assertIs(first_candidate, cl.candidate_by_id[24801])
+        self.assertIs(last_group, cl.group_by_id["AR"])
+
+    def test_fed2016(self):
+        all_candidates_csv = os.path.join(
+            datadir, "fed2016", "common",
+            "2016federalelection-all-candidates-nat-30-06-924.csv")
+        senate_candidates_csv = os.path.join(
+            datadir, "fed2016", "common",
+            "SenateCandidatesDownload-20499.csv")
+
+        cl = CandidateList("WA", all_candidates_csv, senate_candidates_csv)
+
+        self.assertEqual(79, len(cl.candidates))
+        self.assertEqual(28, len(cl.groups))
+
+        first_candidate = cl.candidates[0]
+        self.assertEqual(29437, first_candidate.candidate_id)
+        self.assertEqual("IMISIDES", first_candidate.surname)
+        self.assertEqual("Mark David", first_candidate.given_name)
+        self.assertEqual(0, first_candidate.candidate_pos)
+        self.assertEqual("A", first_candidate.group_id)
+        self.assertEqual(1, first_candidate.ballot_position)
+        self.assertEqual("Christian Democratic Party (Fred Nile Group)",
+                         first_candidate.party_name)
+
+        last_candidate = cl.candidates[-1]
+        self.assertEqual(29428, last_candidate.candidate_id)
+        self.assertEqual("RAMSAY", last_candidate.surname)
+        self.assertEqual("Norm", last_candidate.given_name)
+        self.assertEqual(78, last_candidate.candidate_pos)
+        self.assertEqual("UG", last_candidate.group_id)
+        self.assertEqual(6, last_candidate.ballot_position)
+        self.assertEqual("Independent", last_candidate.party_name)
+
+        first_group = cl.groups[0]
+        self.assertEqual("A", first_group.group_id)
+        self.assertEqual("Christian Democratic Party (Fred Nile Group)",
+                         first_group.party_name)
+        self.assertEqual(2, len(first_group.candidates))
+        self.assertIs(first_candidate, first_group.candidates[0])
+
+        # Even though the "UG" candidates appear last on the ballot,
+        # they do not count as a group.
+        last_group = cl.groups[-1]
+        self.assertEqual("AB", last_group.group_id)
+        self.assertEqual("Family First Party", last_group.party_name)
+
+        # Lookup by ID
+        self.assertIs(first_candidate, cl.candidate_by_id[29437])
+        self.assertIs(last_group, cl.group_by_id["AB"])

--- a/dividebatur/tests/test_candidatelist.py
+++ b/dividebatur/tests/test_candidatelist.py
@@ -26,23 +26,26 @@ class CandidateListTests(unittest.TestCase):
         self.assertEqual(24801, first_candidate.candidate_id)
         self.assertEqual("LEYONHJELM", first_candidate.surname)
         self.assertEqual("David", first_candidate.given_name)
-        self.assertEqual(0, first_candidate.candidate_pos)
+        self.assertEqual(0, first_candidate.candidate_order)
         self.assertEqual("A", first_candidate.group_id)
         self.assertEqual(1, first_candidate.ballot_position)
         self.assertEqual("Liberal Democrats", first_candidate.party_name)
+        self.assertEqual("LDP", first_candidate.party_abbreviation)
 
         last_candidate = cl.candidates[-1]
         self.assertEqual(24866, last_candidate.candidate_id)
         self.assertEqual("La MELA", last_candidate.surname)
         self.assertEqual("John", last_candidate.given_name)
-        self.assertEqual(109, last_candidate.candidate_pos)
+        self.assertEqual(109, last_candidate.candidate_order)
         self.assertEqual("UG", last_candidate.group_id)
         self.assertEqual(4, last_candidate.ballot_position)
         self.assertEqual("Independent", last_candidate.party_name)
+        self.assertEqual("IND", last_candidate.party_abbreviation)
 
         first_group = cl.groups[0]
         self.assertEqual("A", first_group.group_id)
         self.assertEqual("Liberal Democrats", first_group.party_name)
+        self.assertEqual("LDP", first_group.party_abbreviation)
         self.assertEqual(2, len(first_group.candidates))
         self.assertIs(first_candidate, first_group.candidates[0])
 
@@ -51,6 +54,7 @@ class CandidateListTests(unittest.TestCase):
         last_group = cl.groups[-1]
         self.assertEqual("AR", last_group.group_id)
         self.assertEqual("One Nation", last_group.party_name)
+        self.assertEqual("ON", last_group.party_abbreviation)
 
         # Lookup by ID
         self.assertIs(first_candidate, cl.candidate_by_id[24801])
@@ -73,25 +77,28 @@ class CandidateListTests(unittest.TestCase):
         self.assertEqual(29437, first_candidate.candidate_id)
         self.assertEqual("IMISIDES", first_candidate.surname)
         self.assertEqual("Mark David", first_candidate.given_name)
-        self.assertEqual(0, first_candidate.candidate_pos)
+        self.assertEqual(0, first_candidate.candidate_order)
         self.assertEqual("A", first_candidate.group_id)
         self.assertEqual(1, first_candidate.ballot_position)
         self.assertEqual("Christian Democratic Party (Fred Nile Group)",
                          first_candidate.party_name)
+        self.assertEqual("CDP", first_candidate.party_abbreviation)
 
         last_candidate = cl.candidates[-1]
         self.assertEqual(29428, last_candidate.candidate_id)
         self.assertEqual("RAMSAY", last_candidate.surname)
         self.assertEqual("Norm", last_candidate.given_name)
-        self.assertEqual(78, last_candidate.candidate_pos)
+        self.assertEqual(78, last_candidate.candidate_order)
         self.assertEqual("UG", last_candidate.group_id)
         self.assertEqual(6, last_candidate.ballot_position)
         self.assertEqual("Independent", last_candidate.party_name)
+        self.assertEqual("IND", last_candidate.party_abbreviation)
 
         first_group = cl.groups[0]
         self.assertEqual("A", first_group.group_id)
         self.assertEqual("Christian Democratic Party (Fred Nile Group)",
                          first_group.party_name)
+        self.assertEqual("CDP", first_group.party_abbreviation)
         self.assertEqual(2, len(first_group.candidates))
         self.assertIs(first_candidate, first_group.candidates[0])
 
@@ -100,6 +107,7 @@ class CandidateListTests(unittest.TestCase):
         last_group = cl.groups[-1]
         self.assertEqual("AB", last_group.group_id)
         self.assertEqual("Family First Party", last_group.party_name)
+        self.assertEqual("FFP", last_group.party_abbreviation)
 
         # Lookup by ID
         self.assertIs(first_candidate, cl.candidate_by_id[29437])

--- a/dividebatur/tests/test_ticket_sort_key.py
+++ b/dividebatur/tests/test_ticket_sort_key.py
@@ -1,4 +1,4 @@
-from .aecdata import ticket_sort_key
+from ..aecdata import ticket_sort_key
 
 
 def apply_ticket_sort(items):

--- a/travis_tests.sh
+++ b/travis_tests.sh
@@ -5,7 +5,7 @@ set -e
 pip3 install flake8
 pip3 install nose
 
-nosetests dividebatur
+nosetests -v dividebatur
 
 flake8 --ignore=E501 dividebatur
 


### PR DESCRIPTION
While working on my analysis scripts, I found the Candidates/AllCandidates/SenateFlows classes to be a bit of a hassle to work out.  So I had a go at refactoring them into a single simpler CandidateList class.

I converted the SenateCountPost2015 class over to using CandidateList, and the logic looks a bit simpler.  I haven't converted the Pre2015 code over, but it would probably also benefit.

I've removed the AllCandidates and SenateFlows classes.  Candidates is still there since it is the Pre2015 code hasn't been ported yet.