### PR TITLE
Move pre2015 code over to CandidateList

### DIFF
--- a/aec_data/fed2013/aec_fed2013.json
+++ b/aec_data/fed2013/aec_fed2013.json
@@ -10,6 +10,7 @@
             "state" : "NT",
 	    "aec-data" : {
 		"format": "AusSenatePre2015",
+                "all-candidates": "common/2013federalelection-all-candidates-nat-22-08.csv",
 		"senate-candidates": "common/SenateCandidatesDownload-17496.csv",
 		"group-voting-tickets": "common/SenateGroupVotingTicketsDownload-17496.csv",
 		"first-preferences": "common/SenateFirstPrefsByStateByVoteTypeDownload-17496.csv",
@@ -27,6 +28,7 @@
             "state" : "WA",
 	    "aec-data" : {
 		"format": "AusSenatePre2015",
+                "all-candidates": "common/2013federalelection-all-candidates-nat-22-08.csv",
 		"senate-candidates": "common/SenateCandidatesDownload-17496.csv",
 		"group-voting-tickets": "common/SenateGroupVotingTicketsDownload-17496.csv",
 		"first-preferences": "common/SenateFirstPrefsByStateByVoteTypeDownload-17496.csv",

--- a/aec_data/fed2013/profile.json
+++ b/aec_data/fed2013/profile.json
@@ -11,6 +11,7 @@
             "state" : "WA",
 	    "aec-data" : {
 		"format": "AusSenatePre2015",
+                "all-candidates": "common/2013federalelection-all-candidates-nat-22-08.csv",
 		"senate-candidates": "common/SenateCandidatesDownload-17496.csv",
 		"group-voting-tickets": "common/SenateGroupVotingTicketsDownload-17496.csv",
 		"first-preferences": "common/SenateFirstPrefsByStateByVoteTypeDownload-17496.csv",

--- a/aec_data/fed2013_wa/aec_fed2013_wa.json
+++ b/aec_data/fed2013_wa/aec_fed2013_wa.json
@@ -66,6 +66,7 @@
             "state" : "WA",
 	    "aec-data" : {
 		"format": "AusSenatePre2015",
+                "all-candidates": "rerun/data/all-candidates-synthesised.csv",
 		"senate-candidates": "rerun/data/SenateCandidatesDownload-17875.csv",
 		"group-voting-tickets": "rerun/data/SenateGroupVotingTicketsDownload-17875.csv",
 		"first-preferences": "rerun/data/SenateFirstPrefsByStateByVoteTypeDownload-17875.csv",

--- a/aec_data/fed2013_wa/aec_fed2013_wa.json
+++ b/aec_data/fed2013_wa/aec_fed2013_wa.json
@@ -12,6 +12,7 @@
             "state" : "WA",
 	    "aec-data" : {
 		"format": "AusSenatePre2015",
+                "all-candidates": "common/2013federalelection-all-candidates-nat-22-08.csv",
 		"senate-candidates": "common/SenateCandidatesDownload-17496.csv",
 		"group-voting-tickets": "common/SenateGroupVotingTicketsDownload-17496.csv",
 		"first-preferences": "count1/data/SenateFirstPrefsByStateByVoteTypeDownload-17496.csv",
@@ -29,6 +30,7 @@
             "state" : "WA",
 	    "aec-data" : {
 		"format": "AusSenatePre2015",
+                "all-candidates": "common/2013federalelection-all-candidates-nat-22-08.csv",
 		"senate-candidates": "common/SenateCandidatesDownload-17496.csv",
 		"group-voting-tickets": "common/SenateGroupVotingTicketsDownload-17496.csv",
 		"first-preferences": "count2/data/SenateFirstPrefsByStateByVoteTypeDownload-17496.csv",
@@ -46,6 +48,7 @@
             "state" : "WA",
 	    "aec-data" : {
 		"format": "AusSenatePre2015",
+                "all-candidates": "common/2013federalelection-all-candidates-nat-22-08.csv",
 		"senate-candidates": "common/SenateCandidatesDownload-17496.csv",
 		"group-voting-tickets": "common/SenateGroupVotingTicketsDownload-17496.csv",
 		"first-preferences": "count2_plus_1370/data/SenateFirstPrefsByStateByVoteTypeDownload-17496.csv",

--- a/aec_data/fed2013_wa/rerun/data/all-candidates-synthesised.csv
+++ b/aec_data/fed2013_wa/rerun/data/all-candidates-synthesised.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b33c45cd2f3dad356d979fa1df20fff1447be07528f88d953251486bdb689445
+size 5291

--- a/aec_data/fed2013_wa/rerun/data/synthesise-all-candidates.py
+++ b/aec_data/fed2013_wa/rerun/data/synthesise-all-candidates.py
@@ -1,0 +1,36 @@
+#!/usr/bin/python3
+
+# We don't have a copy of the "all-candidates" CSV file for the 2014
+# WA Senate election, so synthesise the parts we care about from the
+# GVT data file.
+
+import csv
+
+all_candidates_columns = ["txn_nm","nom_ty","state_ab","div_nm","ticket","ballot_position","surname","ballot_given_nm","party_ballot_nm","occupation","address_1","address_2","postcode","suburb","address_state_ab","contact_work_ph","contact_home_ph","postal_address_1","postal_address_2","postal_suburb","postal_postcode","contact_fax","postal_state_ab","contact_mobile_no","contact_email"]
+
+with open('all-candidates-synthesised.csv', 'wt') as fp:
+    writer = csv.DictWriter(fp, all_candidates_columns)
+    writer.writeheader()
+
+    with open('SenateGroupVotingTicketsDownload-17875.csv', 'rt') as fp:
+        reader = csv.reader(fp)
+        next(reader)
+        gvt_column_id = {col: i for (i, col) in enumerate(next(reader))}
+        current_ticket = None
+        for t in reader:
+            # We can stop once we've read one entire ticket
+            ticket = (t[gvt_column_id["OwnerGroupNm"]],
+                      t[gvt_column_id["OwnerTicket"]])
+            if current_ticket is not None and current_ticket != ticket:
+                break
+            current_ticket = ticket
+
+            writer.writerow(dict(
+                nom_ty="S",
+                state_ab="WA",
+                ticket=t[gvt_column_id["CandidateTicket"]],
+                surname=t[gvt_column_id["Surname"]],
+                ballot_given_nm=t[gvt_column_id["GivenNm"]],
+                party_ballot_nm=t[gvt_column_id["PartyNm"]],
+                ballot_position=t[gvt_column_id["BallotPosition"]],
+            ))

--- a/aec_data/fed2013_wa/verified.json
+++ b/aec_data/fed2013_wa/verified.json
@@ -12,6 +12,7 @@
             "state" : "WA",
 	    "aec-data" : {
 		"format": "AusSenatePre2015",
+                "all-candidates": "common/2013federalelection-all-candidates-nat-22-08.csv",
 		"senate-candidates": "common/SenateCandidatesDownload-17496.csv",
 		"group-voting-tickets": "common/SenateGroupVotingTicketsDownload-17496.csv",
 		"first-preferences": "count1/data/SenateFirstPrefsByStateByVoteTypeDownload-17496.csv",

--- a/dividebatur/aecdata/__init__.py
+++ b/dividebatur/aecdata/__init__.py
@@ -1,10 +1,9 @@
 from .candidatelist import CandidateList
 from .post2015 import FormalPreferences
-from .pre2015 import Candidates, SenateATL, SenateBTL
+from .pre2015 import SenateATL, SenateBTL
 
 __all__ = [
     "CandidateList",
-    "Candidates",
     "FormalPreferences",
     "SenateATL",
     "SenateBTL",

--- a/dividebatur/aecdata/pre2015.py
+++ b/dividebatur/aecdata/pre2015.py
@@ -13,9 +13,6 @@ class SenateATL:
         self.state_name = state_name
         self.gvt = defaultdict(list)
         self.ticket_votes = []
-        self.individual_candidate_ids = []
-        self.candidate_order = {}
-        self.candidate_title = {}
         self.btl_firstprefs = {}
         self.raw_ticket_data = []
         self.load_tickets(gvt_csv)
@@ -57,9 +54,6 @@ class SenateATL:
                     elif row.CandidateDetails != 'Unapportioned':
                         assert(row.CandidateID not in self.btl_firstprefs)
                         self.btl_firstprefs[row.CandidateID] = row.TotalVotes
-                        self.individual_candidate_ids.append(row.CandidateID)
-                self.candidate_order[row.CandidateID] = idx
-                self.candidate_title[row.CandidateID] = row.CandidateDetails
 
     def get_tickets(self):
         # GVT handling: see s272 of the electoral act (as collated in 2013)
@@ -75,15 +69,6 @@ class SenateATL:
             # remainder_pattern = [0] * (size-remainder) + [1] * remainder
             for ticket, extra in zip(self.gvt[group], remainder_pattern):
                 yield ticket, int(n / size) + extra
-
-    def get_candidate_ids(self):
-        return self.individual_candidate_ids
-
-    def get_candidate_order(self, candidate_id):
-        return self.candidate_order[candidate_id]
-
-    def get_candidate_title(self, candidate_id):
-        return self.candidate_title[candidate_id]
 
 
 class SenateBTL:

--- a/dividebatur/aecdata/pre2015.py
+++ b/dividebatur/aecdata/pre2015.py
@@ -6,43 +6,10 @@ from .utils import int_or_none, named_tuple_iter, ticket_sort_key
 from ..counter import Ticket
 
 
-class Candidates:
-    "parses AEC candidates CSV file"
-
-    def __init__(self, candidates_csv):
-        self.by_id = {}
-        self.by_name_party = {}
-        self.candidates = []
-        self.load(candidates_csv)
-
-    def load(self, candidates_csv):
-        with open(candidates_csv, 'rt') as fd:
-            reader = csv.reader(fd)
-            next(reader)  # skip the version
-            header = next(reader)
-            for candidate in named_tuple_iter(
-                    'Candidate', reader, header, CandidateID=int):
-                self.candidates.append(candidate)
-                assert(candidate.CandidateID not in self.by_id)
-                self.by_id[candidate.CandidateID] = candidate
-                k = (candidate.Surname, candidate.GivenNm, candidate.PartyNm)
-                assert(k not in self.by_name_party)
-                self.by_name_party[k] = candidate
-
-    def lookup_id(self, candidate_id):
-        return self.by_id[candidate_id]
-
-    def lookup_name_party(self, surname, given_name, party):
-        return self.by_name_party[(surname, given_name, party)]
-
-    def get_parties(self):
-        return dict((t.PartyAb, t.PartyNm) for t in self.candidates if t)
-
-
 class SenateATL:
     "parses AEC candidates Senate ATL data file (pre-2015)"
 
-    def __init__(self, state_name, candidates, gvt_csv, firstprefs_csv):
+    def __init__(self, state_name, gvt_csv, firstprefs_csv):
         self.state_name = state_name
         self.gvt = defaultdict(list)
         self.ticket_votes = []
@@ -51,17 +18,17 @@ class SenateATL:
         self.candidate_title = {}
         self.btl_firstprefs = {}
         self.raw_ticket_data = []
-        self.load_tickets(candidates, gvt_csv)
+        self.load_tickets(gvt_csv)
         self.load_first_preferences(state_name, firstprefs_csv)
 
-    def load_tickets(self, candidates, gvt_csv):
+    def load_tickets(self, gvt_csv):
         with open(gvt_csv, 'rt') as fd:
             reader = csv.reader(fd)
             # skip introduction line
             next(reader)
             header = next(reader)
             it = sorted(
-                named_tuple_iter('GvtRow', reader, header, PreferenceNo=int, TicketNo=int, OwnerTicket=lambda t: t.strip()),
+                named_tuple_iter('GvtRow', reader, header, PreferenceNo=int, TicketNo=int, CandidateID=int, OwnerTicket=lambda t: t.strip()),
                 key=lambda gvt: (gvt.State, ticket_sort_key(gvt.OwnerTicket), gvt.TicketNo, gvt.PreferenceNo))
             for (state_ab, ticket, ticket_no), g in itertools.groupby(
                     it, lambda gvt: (gvt.State, gvt.OwnerTicket, gvt.TicketNo)):
@@ -69,10 +36,8 @@ class SenateATL:
                     continue
                 prefs = []
                 for ticket_entry in g:
-                    candidate = candidates.lookup_name_party(
-                        ticket_entry.Surname, ticket_entry.GivenNm, ticket_entry.PartyNm)
                     prefs.append(
-                        (ticket_entry.PreferenceNo, candidate.CandidateID))
+                        (ticket_entry.PreferenceNo, ticket_entry.CandidateID))
 
                 non_none = [x for x in prefs if x[0] is not None]
                 self.raw_ticket_data.append(sorted(non_none, key=lambda x: x[0]))
@@ -128,12 +93,12 @@ class SenateBTL:
     (pre-2015)
     """
 
-    def __init__(self, candidates, btl_csv):
+    def __init__(self, btl_csv):
         self.ticket_votes = defaultdict(int)
         self.raw_ticket_data = []
-        self.load_btl(candidates, btl_csv)
+        self.load_btl(btl_csv)
 
-    def load_btl(self, candidates, btl_csv):
+    def load_btl(self, btl_csv):
         with open(btl_csv, 'rt') as fd:
             reader = csv.reader(fd)
             next(reader)  # skip the version

--- a/dividebatur/senatecount.py
+++ b/dividebatur/senatecount.py
@@ -9,7 +9,7 @@ import re
 import glob
 from pprint import pprint, pformat
 from .counter import PapersForCount, SenateCounter, Ticket
-from .aecdata import Candidates, CandidateList, SenateATL, SenateBTL, FormalPreferences
+from .aecdata import CandidateList, SenateATL, SenateBTL, FormalPreferences
 
 
 class SenateCountPost2015:
@@ -123,13 +123,14 @@ class SenateCountPre2015:
         if 's282_recount' in kwargs:
             raise Exception('s282 recount not implemented for pre2015 data')
 
-        self.candidates = Candidates(get_input_file('senate-candidates'))
+        self.candidates = CandidateList(state_name,
+                                        get_input_file('all-candidates'),
+                                        get_input_file('senate-candidates'))
         self.atl = SenateATL(
             state_name,
-            self.candidates,
             get_input_file('group-voting-tickets'),
             get_input_file('first-preferences'))
-        self.btl = SenateBTL(self.candidates, get_input_file('btl-preferences'))
+        self.btl = SenateBTL(get_input_file('btl-preferences'))
 
         def load_tickets(ticket_obj):
             if ticket_obj is None:
@@ -144,19 +145,21 @@ class SenateCountPre2015:
         return self.tickets_for_count
 
     def get_candidate_ids(self):
-        return self.atl.get_candidate_ids()
+        return [c.candidate_id for c in self.candidates.candidates]
 
     def get_parties(self):
-        return self.candidates.get_parties()
+        return dict((c.party_abbreviation, c.party_name)
+                    for c in self.candidates.candidates)
 
     def get_candidate_title(self, candidate_id):
-        return self.atl.get_candidate_title(candidate_id)
+        c = self.candidates.candidate_by_id[candidate_id]
+        return "{}, {}".format(c.surname, c.given_name)
 
     def get_candidate_order(self, candidate_id):
-        return self.atl.get_candidate_order(candidate_id)
+        return self.candidates.candidate_by_id[candidate_id].candidate_order
 
     def get_candidate_party(self, candidate_id):
-        return self.candidates.lookup_id(candidate_id).PartyAb
+        return self.candidates.candidate_by_id[candidate_id].party_abbreviation
 
 
 def verify_test_logs(verified_dir, test_log_dir):


### PR DESCRIPTION
This is the other half of the CandidateList refactor, covering the code dealing with the pre2015 data formats.

It turned out to be fairly simple, with the old Candidates class not being used for as much as I thought it might be.

One complication was that there wasn't a copy of the all-candidates file for the 2014 WA Senate election.  I'm not sure whether it just wasn't made available, or just wasn't archived (it isn't in the VTR archive).  I was able to synthesise a skeleton version of the file from the group voting ticket CSV file though, which seems to give the correct results.

Perhaps this is something worth bringing up with the AEC, since if they follow current procedure there won't be enough data on the VTR archive website to reproduce the 2016 results :(