### PR TITLE
Add ``automation_fn`` arg to ``senatecount.get_outcome``; Fix Small Errors

### DIFF
--- a/dividebatur/counter.py
+++ b/dividebatur/counter.py
@@ -314,7 +314,7 @@ class SenateCounter:
         if self.candidate_tie_callback is not None:
             resp = self.candidate_tie_callback(candidates)
         if resp is not None:
-            entry.log("%s\nautomation: '%s' entered" % (qn, resp), echo=True)
+            entry.log("%s\nautomation: '%s' entered" % (qn, resp + 1), echo=True)
             return resp
         else:
             entry.log(qn, echo=True, end='')
@@ -352,7 +352,7 @@ class SenateCounter:
                 with LogEntry(round_log) as entry:
                     entry.log("Multiple candidates elected with %d votes." % (votes), echo=True)
                     for candidate_id in candidate_ids:
-                        entry.log("    %s" % (self.candidate_title[candidate_id]), echo=True)
+                        entry.log("    %s" % (self.candidate_title(candidate_id)), echo=True)
                     tie_breaker_round = self.find_tie_breaker(candidate_ids)
                     if tie_breaker_round is not None:
                         entry.log("Tie broken from previous totals", echo=True)
@@ -609,7 +609,7 @@ class SenateCounter:
         sorted_candidate_ids = list(sorted(candidate_ids, key=self.candidate_title))
         for idx, candidate_id in enumerate(sorted_candidate_ids):
             entry.log("[%3d] - %s" % (idx + 1, self.candidate_title(candidate_id)), echo=True)
-        return sorted_candidate_ids[self.determine_candidate_tie(entry, question, len(sorted_candidate_ids))]
+        return sorted_candidate_ids[self.determine_candidate_tie(entry, question, sorted_candidate_ids)]
 
     def candidate_to_exclude(self, round_log, candidate_aggregates):
         def eligible(candidate_id):

--- a/dividebatur/senatecount.py
+++ b/dividebatur/senatecount.py
@@ -251,7 +251,7 @@ def json_count_path(out_dir, shortname):
     return os.path.join(out_dir, shortname + '.json')
 
 
-def get_outcome(count, count_data, base_dir, out_dir):
+def get_outcome(count, count_data, base_dir, out_dir, automation_fn=None):
     test_logs_okay = True
     test_log_dir = None
     if 'verified' in count:
@@ -274,7 +274,8 @@ def get_outcome(count, count_data, base_dir, out_dir):
         description=count.get('description'),
         house=count['house'],
         state=count['state'])
-    automation_fn = make_automation(count.get('automation', []))
+    if automation_fn is None:
+        automation_fn = make_automation(count.get('automation', []))
     counter.set_election_order_callback(automation_fn)
     counter.set_candidate_tie_callback(automation_fn)
     counter.run()


### PR DESCRIPTION
Changes in this PR:
* Added a default arg to the ``senatecount.get_outcome`` method that accepts an automation function, else uses make_automation function.
* Fixed an off-by-one error related to the index shown when an automated choice is made.
* Fixed a small error where parentheses were expected instead of brackets.
* Fixed an argument to ``determine_candidate_tie`` which should accept a list of candidate IDs rather than the number of candidate IDS.